### PR TITLE
UNO button fix and pass button action improve

### DIFF
--- a/src/main/java/univalle/tedesoft/uno/controller/GameController.java
+++ b/src/main/java/univalle/tedesoft/uno/controller/GameController.java
@@ -463,17 +463,15 @@ public class GameController {
         // Actualizar mensaje y controles
         this.gameView.clearPlayerHandHighlights();
         this.gameView.highlightDeck(false);
-        this.canPunishMachine = false; // Resetear al cambiar de turno
         this.gameView.updateTurnIndicator(this.currentPlayer.getName());
         this.gameView.displayMessage("Turno de " + this.currentPlayer.getName());
-        this.updateInteractionBasedOnTurn();
+        this.canPunishMachine = false; // Resetear el condicional de castigar
 
         // Lógica para que la máquina "atrape" al humano
         // Chequea si el humano TIENE 1 carta y NO ha declarado UNO en su turno.
         if (this.currentPlayer == this.machinePlayer) {
-            if (previousPlayer == this.humanPlayer &&
-                    this.humanPlayer.getNumeroCartas() == 1 &&
-                    !this.humanPlayer.hasDeclaredUnoThisTurn()) {
+            this.cancelMachineCatchUnoTimer();
+            if (previousPlayer == this.humanPlayer &&  this.humanPlayer.getNumeroCartas() == 1 &&  !this.humanPlayer.hasDeclaredUnoThisTurn()) {
                 this.startMachineCatchUnoTimer();
             } else {
                 this.cancelMachineCatchUnoTimer();
@@ -491,6 +489,8 @@ public class GameController {
             }
             this.updatePunishUnoButtonVisuals();
         }
+        // Actualizar la interacción y los botones después de toda la lógica de cambio de turno
+        this.updateInteractionBasedOnTurn();
     }
 
     /**

--- a/src/main/java/univalle/tedesoft/uno/controller/GameController.java
+++ b/src/main/java/univalle/tedesoft/uno/controller/GameController.java
@@ -33,7 +33,6 @@ public class GameController {
     @FXML public Label messageLabel;
     @FXML public Label turnLabel;
     @FXML public HBox playerHandHBox;
-    @FXML public Button passButton;
     @FXML public Button unoButton;
     @FXML public ProgressIndicator unoTimerIndicator;
     @FXML public Button restartButton;
@@ -299,7 +298,6 @@ public class GameController {
             // Comprobar si la carta robada se puede jugar
             if (this.gameState.isValidPlay(drawnCard)) {
                 this.gameView.displayMessage("¡Robaste una carta jugable! Puedes jugarla o pasar.");
-                this.gameView.enablePassButton(true);
             } else {
                 // Pasar turno automáticamente si no es jugable
                 // TODO: evaluar si esto es válido de acuerdo a los requerimientos
@@ -373,35 +371,6 @@ public class GameController {
     @FXML
     public void handleRestartButtonAction(ActionEvent actionEvent) {
         this.startNewGame();
-    }
-
-    /**
-     * Maneja la acción del botón "Pasar".
-     * @param actionEvent El evento de acción.
-     */
-    @FXML
-    public void handlePassButtonAction(ActionEvent actionEvent) {
-        // TODO: mejorar la legibilidad de este operador ternario
-        if (this.gameState.isGameOver() || this.currentPlayer != this.humanPlayer || this.isChoosingColor) {
-            this.gameView.displayMessage(this.gameState.isGameOver() ? "El juego ha terminado." :
-                    (this.isChoosingColor ? "Elige un color primero." : "Espera tu turno."));
-            return;
-        }
-        this.canPunishMachine = false; // Si el humano pasa, pierde la oportunidad de castigar
-        this.updatePunishUnoButtonVisuals();
-        // Penalizar si era candidato a UNO y pasa en lugar de decir UNO
-        if (this.humanPlayer.isUnoCandidate()) {
-            this.penalizeHumanForMissingUno("¡Debiste decir UNO antes de pasar!");
-            this.humanPlayer.resetUnoStatus();
-            this.processTurnAdvancement();
-            return;
-        }
-        this.cancelHumanUnoTimer(); // Cancelar cualquier timer de UNO pendiente
-        this.updateUnoVisualsForHuman(); // Ocultar botón/timer de UNO
-
-        this.gameView.clearPlayerHandHighlights();
-        this.gameView.displayMessage("Turno pasado.");
-        this.processTurnAdvancement();
     }
 
     /**
@@ -670,7 +639,6 @@ public class GameController {
                 !this.gameState.isGameOver() &&
                 !this.isChoosingColor);
         this.gameView.enablePlayerInteraction(canInteractBase);
-        this.gameView.enablePassButton(canInteractBase);
         this.updatePunishUnoButtonVisuals();
         // TODO: toca revisar este método
     }

--- a/src/main/java/univalle/tedesoft/uno/model/Players/Player.java
+++ b/src/main/java/univalle/tedesoft/uno/model/Players/Player.java
@@ -6,7 +6,7 @@ import univalle.tedesoft.uno.model.Cards.Card;
 
 /**
  * Clase que representa un jugador en el juego UNO.
- * Contiene la lista de cartas del jugador y metodos basicos para
+ * Contiene la lista de cartas del jugador y métodos básicos para
  * agregar, remover y contar cartas en su mano.
  * @author David Esteban Valencia
  * @author Santiago David Guerrero
@@ -18,6 +18,14 @@ public class Player {
     public List<Card> cards = new ArrayList<>();
 
     public String name;
+    /**
+     * Indicador para un jugador que tiene la ventana de oportunidad para declarar "UNO".
+     */
+    private boolean isUnoCandidate = false;
+    /**
+     * Indicar para un jugador que efectivamente declaró "UNO" durante su ventana de oportunidad.
+     */
+    private boolean hasDeclaredUnoThisTurn = false;
 
     /**
      * Constructor por defecto del jugador.
@@ -72,5 +80,46 @@ public class Player {
      */
     public void clearHand() {
         this.cards.clear();
+    }
+
+    /**
+     * Verifica si el jugador es actualmente un candidato para declarar "UNO".
+     * (Tiene 1 carta y está en la ventana de oportunidad).
+     * @return true si es candidato a UNO, false en caso contrario.
+     */
+    public boolean isUnoCandidate() {
+        return this.isUnoCandidate;
+    }
+
+    /**
+     * Establece si el jugador es un candidato para declarar "UNO".
+     * @param unoCandidate true si es candidato, false en caso contrario.
+     */
+    public void setUnoCandidate(boolean unoCandidate) {
+        this.isUnoCandidate = unoCandidate;
+    }
+
+    /**
+     * Verifica si el jugador ha declarado "UNO" en la oportunidad actual.
+     * @return true si ya declaró UNO, false en caso contrario.
+     */
+    public boolean hasDeclaredUnoThisTurn() {
+        return this.hasDeclaredUnoThisTurn;
+    }
+
+    /**
+     * Establece si el jugador ha declarado "UNO" en la oportunidad actual.
+     * @param hasDeclaredUnoThisTurn true si declaró UNO, false en caso contrario.
+     */
+    public void setHasDeclaredUnoThisTurn(boolean hasDeclaredUnoThisTurn) {
+        this.hasDeclaredUnoThisTurn = hasDeclaredUnoThisTurn;
+    }
+
+    /**
+     * Resetea los estados relacionados con la declaración de "UNO" del jugador.
+     */
+    public void resetUnoStatus() {
+        this.isUnoCandidate = false;
+        this.hasDeclaredUnoThisTurn = false;
     }
 }

--- a/src/main/java/univalle/tedesoft/uno/model/State/GameState.java
+++ b/src/main/java/univalle/tedesoft/uno/model/State/GameState.java
@@ -74,7 +74,10 @@ public class GameState implements IGameState {
         this.dealInitialCards();
 
         // Sacar una carta y colocarla en la pila de descarte
-        Card firstCard = this.takeSingleCardFromDeckInternal();
+        Card firstCard = null;
+        do {
+            firstCard = this.takeSingleCardFromDeckInternal();
+        } while (firstCard instanceof ActionCard);
         this.discardStack.discard(firstCard);
 
         // Establecer color y valor por defecto iniciales

--- a/src/main/java/univalle/tedesoft/uno/model/State/IGameState.java
+++ b/src/main/java/univalle/tedesoft/uno/model/State/IGameState.java
@@ -113,4 +113,17 @@ public interface IGameState {
      * el siguiente jugador debe perder su turno.
      */
     void advanceTurn();
+
+    /**
+     * Aplica una penalización al jugador especificado por no haber declarado "UNO"
+     * de acuerdo con las reglas del juego.
+     * @param playerToPenalize El jugador que recibirá la penalización.
+     */
+    void penalizePlayerForUno(Player playerToPenalize);
+
+    /**
+     * Registra que el jugador especificado ha declarado "UNO" correctamente.
+     * @param player El jugador que ha declarado "UNO".
+     */
+    void playerDeclaresUno(Player player);
 }

--- a/src/main/java/univalle/tedesoft/uno/model/State/IGameState.java
+++ b/src/main/java/univalle/tedesoft/uno/model/State/IGameState.java
@@ -86,8 +86,18 @@ public interface IGameState {
      */
     void onMustChooseColor(Player player);
 
+    /**
+     * Retorna al ganador del juego una vez que este termina.
+     * @return la instancia de Player que representa al ganador del juego,
+     * o null si aún no hay un ganador o el juego no ha terminado.
+     */
     Player getWinner();
 
+    /**
+     * Retorna una descripción textual de una carta dada, incluyendo su valor y color.
+     * @param card La carta para la que se proporcionará la descripción.
+     * @return un texto que contiene la descripción de la carta.
+     */
     String getCardDescription(Card card);
 
     /**
@@ -98,7 +108,9 @@ public interface IGameState {
     Card drawTurnCard(Player player);
 
     /**
-     *
+     * Avanza el turno al siguiente jugador. Gestiona la transición entre el jugador actual y
+     * y el siguiente en la secuencia lógica del juego 2v2. I.e. si un jugador usa una carta SKIP,
+     * el siguiente jugador debe perder su turno.
      */
     void advanceTurn();
 }

--- a/src/main/java/univalle/tedesoft/uno/view/GameView.java
+++ b/src/main/java/univalle/tedesoft/uno/view/GameView.java
@@ -237,14 +237,6 @@ public class GameView extends Stage {
     }
 
     /**
-     * Habilita o deshabilita el botón de "Pasar"
-     * @param enable true para habilitar, false para deshabilitar.
-     */
-    public void enablePassButton(boolean enable) {
-        Platform.runLater(() -> this.gameController.passButton.setDisable(!enable));
-    }
-
-    /**
      * Muestra u oculta el botón "UNO!".
      * @param show true para mostrar, false para ocultar.
      */
@@ -288,7 +280,6 @@ public class GameView extends Stage {
     public void disableGameInteractions() {
         Platform.runLater(() -> {
             this.enablePlayerInteraction(false);
-            this.enablePassButton(false);
             this.showUnoButton(false);
             this.gameController.aidButton.setDisable(true);
         });
@@ -434,7 +425,6 @@ public class GameView extends Stage {
             // Ocultar y deshabilitar botones relevantes
             this.gameController.unoButton.setVisible(false);
             this.gameController.unoTimerIndicator.setVisible(false);
-            this.gameController.passButton.setDisable(true);
             this.gameController.aidButton.setDisable(true);
             this.gameController.restartButton.setDisable(false);
 

--- a/src/main/java/univalle/tedesoft/uno/view/GameView.java
+++ b/src/main/java/univalle/tedesoft/uno/view/GameView.java
@@ -6,6 +6,7 @@ import javafx.geometry.Insets;
 import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.ChoiceDialog;
+import javafx.scene.control.ProgressIndicator;
 import javafx.scene.control.Tooltip;
 import javafx.scene.effect.DropShadow;
 import javafx.scene.image.Image;
@@ -248,7 +249,11 @@ public class GameView extends Stage {
      * @param show true para mostrar, false para ocultar.
      */
     public void showUnoButton(boolean show) {
-        Platform.runLater(() -> this.gameController.unoButton.setVisible(show));
+        Platform.runLater(() -> {
+            if (this.gameController.unoButton != null) {
+                this.gameController.unoButton.setVisible(show);
+            }
+        });
     }
 
     /**
@@ -256,8 +261,17 @@ public class GameView extends Stage {
      * @param show true para mostrar, false para ocultar.
      */
     public void showUnoPenaltyTimer(boolean show) {
-        // TODO: implementar el temporizador de penalización
-        Platform.runLater(() -> this.gameController.unoTimerIndicator.setVisible(show));
+        Platform.runLater(() -> {
+            if (this.gameController.unoTimerIndicator != null) {
+                this.gameController.unoTimerIndicator.setVisible(show);
+                if (show) {
+                    // Puedes usar INDETERMINATE_PROGRESS o un valor fijo si no hay cuenta regresiva
+                    this.gameController.unoTimerIndicator.setProgress(ProgressIndicator.INDETERMINATE_PROGRESS);
+                } else {
+                    this.gameController.unoTimerIndicator.setProgress(0); // Resetear progreso al ocultar
+                }
+            }
+        });
     }
 
     /**
@@ -412,7 +426,6 @@ public class GameView extends Stage {
             this.gameController.playerHandHBox.getChildren().clear();
             this.gameController.machineHandHBox.getChildren().clear();
             this.gameController.messageLabel.setText("Iniciando nueva partida...");
-//            this.gameController.turnLabel.setText("Turno de:");
             this.gameController.machineCardsCountLabel.setText("Cartas Máquina: ?");
 
             // Restablecer imágenes por defecto
@@ -425,6 +438,8 @@ public class GameView extends Stage {
             this.gameController.aidButton.setDisable(true);
             this.gameController.restartButton.setDisable(false);
 
+            this.showUnoButton(false);
+            this.showUnoPenaltyTimer(false);
             // Limpiar resaltados
             this.clearPlayerHandHighlights();
             this.highlightDeck(false);

--- a/src/main/resources/univalle/tedesoft/uno/game-view.fxml
+++ b/src/main/resources/univalle/tedesoft/uno/game-view.fxml
@@ -70,8 +70,15 @@
     </left>
     <right>
         <VBox alignment="TOP_CENTER" prefWidth="130.0" spacing="30.0" BorderPane.alignment="CENTER">
+            <padding>
+                <Insets top="30.0" left="20.0" right="20.0" bottom="30.0" /> <!-- Añadido bottom padding -->
+            </padding>
             <Button fx:id="aidButton" mnemonicParsing="false" onAction="#handleAidButtonAction" text="?"
                 style="-fx-background-color: linear-gradient(to bottom, #2ecc71, #27ae60); -fx-text-fill: white; -fx-font-size: 22px; -fx-font-weight: bold; -fx-background-radius: 8; -fx-padding: 10 20; -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.2), 5, 0, 0, 2);"/>
+            <Button fx:id="punishUnoButton" mnemonicParsing="false" onAction="#handlePunishUnoButtonAction" text="¡Atrapar!"
+                    style="-fx-background-color: linear-gradient(to bottom, #f1c40f, #f39c12); -fx-text-fill: #2c3e50; -fx-font-weight: bold; -fx-font-size: 13px; -fx-background-radius: 8; -fx-padding: 10 15; -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.2), 5, 0, 0, 2);"
+                    prefHeight="60.0" prefWidth="80.0" visible="false" disable="true">
+            </Button>
             <padding>
                 <Insets top="30.0" left="20.0" right="20.0" />
             </padding>

--- a/src/main/resources/univalle/tedesoft/uno/game-view.fxml
+++ b/src/main/resources/univalle/tedesoft/uno/game-view.fxml
@@ -1,42 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.ProgressIndicator?>
+<?import javafx.scene.effect.DropShadow?>
 <?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
-<?import javafx.geometry.Insets?>
-<?import javafx.scene.effect.DropShadow?>
-<?import javafx.scene.effect.InnerShadow?>
-<?import javafx.scene.effect.BlurType?>
-<?import javafx.scene.paint.LinearGradient?>
-<?import javafx.scene.paint.Stop?>
-<?import javafx.scene.paint.CycleMethod?>
 
-<BorderPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="700.0" prefWidth="900.0" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1" fx:controller="univalle.tedesoft.uno.controller.GameController" style="-fx-background-color: linear-gradient(to bottom, #f5f7fa, #c3cfe2);">
+<BorderPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="700.0" prefWidth="900.0" style="-fx-background-color: linear-gradient(to bottom, #f5f7fa, #c3cfe2);" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="univalle.tedesoft.uno.controller.GameController">
     <top>
-        <VBox alignment="CENTER" prefHeight="200.0" spacing="15.0" BorderPane.alignment="CENTER" style="-fx-background-color: rgba(255,255,255,0.9); -fx-background-radius: 15; -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.2), 15, 0, 0, 3);">
-            <Label fx:id="playerNameLabel" text="Jugador: " style="-fx-font-size: 18px; -fx-font-weight: bold; -fx-text-fill: #2c3e50; -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.1), 2, 0, 0, 1);"/>
-            <Label fx:id="machineCardsCountLabel" text="Cartas Máquina: 5" style="-fx-font-size: 18px; -fx-font-weight: bold; -fx-text-fill: #2c3e50; -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.1), 2, 0, 0, 1);"/>
+        <VBox alignment="CENTER" prefHeight="200.0" spacing="15.0" style="-fx-background-color: rgba(255,255,255,0.9); -fx-background-radius: 15; -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.2), 15, 0, 0, 3);" BorderPane.alignment="CENTER">
+            <Label fx:id="playerNameLabel" style="-fx-font-size: 18px; -fx-font-weight: bold; -fx-text-fill: #2c3e50; -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.1), 2, 0, 0, 1);" text="Jugador: " />
+            <Label fx:id="machineCardsCountLabel" style="-fx-font-size: 18px; -fx-font-weight: bold; -fx-text-fill: #2c3e50; -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.1), 2, 0, 0, 1);" text="Cartas Máquina: 5" />
             <HBox fx:id="machineHandHBox" alignment="CENTER" prefHeight="120.0" spacing="8.0">
             </HBox>
             <padding>
-                <Insets top="20.0" bottom="20.0" left="25.0" right="25.0" />
+                <Insets bottom="20.0" left="25.0" right="25.0" top="20.0" />
             </padding>
         </VBox>
     </top>
     <center>
         <HBox alignment="CENTER" prefHeight="200.0" spacing="100.0" BorderPane.alignment="CENTER">
-            <ImageView fx:id="deckImageView" fitHeight="130.0" pickOnBounds="true" preserveRatio="true" onMouseClicked="#handleMazoClick">
+            <ImageView fx:id="deckImageView" fitHeight="130.0" onMouseClicked="#handleMazoClick" pickOnBounds="true" preserveRatio="true">
                 <effect>
-                    <DropShadow radius="8.0" offsetX="3.0" offsetY="3.0" color="#00000080"/>
+                    <DropShadow color="#00000080" offsetX="3.0" offsetY="3.0" radius="8.0" />
                 </effect>
             </ImageView>
             <ImageView fx:id="discardPileImageView" fitHeight="130.0" pickOnBounds="true" preserveRatio="true">
                 <effect>
-                    <DropShadow radius="8.0" offsetX="3.0" offsetY="3.0" color="#00000080"/>
+                    <DropShadow color="#00000080" offsetX="3.0" offsetY="3.0" radius="8.0" />
                 </effect>
             </ImageView>
         </HBox>
@@ -48,40 +43,29 @@
             <HBox fx:id="playerHandHBox" alignment="CENTER" prefHeight="120.0" spacing="8.0">
             </HBox>
             <HBox alignment="CENTER" spacing="40.0">
-                <Button fx:id="passButton" mnemonicParsing="false" onAction="#handlePassButtonAction" text="Pasar"
-                    style="-fx-background-color: linear-gradient(to bottom, #e74c3c, #c0392b); -fx-text-fill: white; -fx-font-weight: bold; -fx-font-size: 14px; -fx-background-radius: 8; -fx-padding: 10 25; -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.2), 5, 0, 0, 2);"/>
-                <Button fx:id="unoButton" mnemonicParsing="false" onAction="#handleUnoButtonAction" text="UNO!"
-                    style="-fx-background-color: linear-gradient(to bottom, #f1c40f, #f39c12); -fx-text-fill: #2c3e50; -fx-font-weight: bold; -fx-font-size: 18px; -fx-background-radius: 8; -fx-padding: 10 25; -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.2), 5, 0, 0, 2);"/>
-                <ProgressIndicator fx:id="unoTimerIndicator" progress="0.0" prefWidth="45.0" prefHeight="45.0" style="-fx-progress-color: #2ecc71;"/>
+                <Button fx:id="punishUnoButton" mnemonicParsing="false" onAction="#handlePunishUnoButtonAction" prefHeight="60.0" style="-fx-background-color: linear-gradient(to bottom, #f1c40f, #f39c12); -fx-text-fill: #2c3e50; -fx-font-weight: bold; -fx-font-size: 18px; -fx-background-radius: 8; -fx-padding: 10 15; -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.2), 5, 0, 0, 2);" text="CANTA!" />
+                <Button fx:id="unoButton" mnemonicParsing="false" onAction="#handleUnoButtonAction" style="-fx-background-color: linear-gradient(to bottom, #f1c40f, #f39c12); -fx-text-fill: #2c3e50; -fx-font-weight: bold; -fx-font-size: 18px; -fx-background-radius: 8; -fx-padding: 10 25; -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.2), 5, 0, 0, 2);" text="UNO!" />
+                <ProgressIndicator fx:id="unoTimerIndicator" prefHeight="45.0" prefWidth="45.0" progress="0.0" style="-fx-progress-color: #2ecc71;" />
                 <padding>
-                    <Insets top="20.0" bottom="30.0" />
+                    <Insets bottom="30.0" top="20.0" />
                 </padding>
             </HBox>
         </VBox>
     </bottom>
     <left>
         <VBox alignment="TOP_CENTER" prefWidth="130.0" spacing="30.0" BorderPane.alignment="CENTER">
-            <Button fx:id="restartButton" mnemonicParsing="false" onAction="#handleRestartButtonAction" text="Reiniciar"
-                style="-fx-background-color: linear-gradient(to bottom, #3498db, #2980b9); -fx-text-fill: white; -fx-font-weight: bold; -fx-font-size: 14px; -fx-background-radius: 8; -fx-padding: 10 20; -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.2), 5, 0, 0, 2);"/>
+            <Button fx:id="restartButton" mnemonicParsing="false" onAction="#handleRestartButtonAction" style="-fx-background-color: linear-gradient(to bottom, #3498db, #2980b9); -fx-text-fill: white; -fx-font-weight: bold; -fx-font-size: 14px; -fx-background-radius: 8; -fx-padding: 10 10; -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.2), 5, 0, 0, 2);" text="Reiniciar" />
             <padding>
-                <Insets top="30.0" left="20.0" right="20.0" />
+                <Insets left="20.0" right="20.0" top="30.0" />
             </padding>
         </VBox>
     </left>
     <right>
         <VBox alignment="TOP_CENTER" prefWidth="130.0" spacing="30.0" BorderPane.alignment="CENTER">
             <padding>
-                <Insets top="30.0" left="20.0" right="20.0" bottom="30.0" /> <!-- Añadido bottom padding -->
+                <Insets bottom="30.0" left="20.0" right="20.0" top="30.0" />
             </padding>
-            <Button fx:id="aidButton" mnemonicParsing="false" onAction="#handleAidButtonAction" text="?"
-                style="-fx-background-color: linear-gradient(to bottom, #2ecc71, #27ae60); -fx-text-fill: white; -fx-font-size: 22px; -fx-font-weight: bold; -fx-background-radius: 8; -fx-padding: 10 20; -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.2), 5, 0, 0, 2);"/>
-            <Button fx:id="punishUnoButton" mnemonicParsing="false" onAction="#handlePunishUnoButtonAction" text="¡Atrapar!"
-                    style="-fx-background-color: linear-gradient(to bottom, #f1c40f, #f39c12); -fx-text-fill: #2c3e50; -fx-font-weight: bold; -fx-font-size: 13px; -fx-background-radius: 8; -fx-padding: 10 15; -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.2), 5, 0, 0, 2);"
-                    prefHeight="60.0" prefWidth="80.0" visible="false" disable="true">
-            </Button>
-            <padding>
-                <Insets top="30.0" left="20.0" right="20.0" />
-            </padding>
+            <Button fx:id="aidButton" mnemonicParsing="false" onAction="#handleAidButtonAction" style="-fx-background-color: linear-gradient(to bottom, #2ecc71, #27ae60); -fx-text-fill: white; -fx-font-size: 22px; -fx-font-weight: bold; -fx-background-radius: 8; -fx-padding: 10 20; -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.2), 5, 0, 0, 2);" text="?" />
         </VBox>
     </right>
 </BorderPane>


### PR DESCRIPTION
This PR aims to improves the UNO button and the pass button which have a bug currently. 

The necessary logic was added to define a 2- to 4-second time window in which a player can declare UNO. This logic was implemented so that the machine randomly declares it within this window. A new button was also added so the player can punish the machine. The pass button was removed.