### PR TITLE
UNO window and ActionCards bug in machine turn

### DIFF
--- a/src/main/java/univalle/tedesoft/uno/model/State/IGameState.java
+++ b/src/main/java/univalle/tedesoft/uno/model/State/IGameState.java
@@ -135,4 +135,9 @@ public interface IGameState {
      * @param player El jugador que ha declarado "UNO".
      */
     void playerDeclaresUno(Player player);
+
+    /**
+     * Aplica cualquier penalización o efecto de robo pendiente al jugador humano en el juego.
+     */
+    void applyPendingDrawsToHuman();
 }

--- a/src/main/java/univalle/tedesoft/uno/threads/MachineDeclareUnoRunnable.java
+++ b/src/main/java/univalle/tedesoft/uno/threads/MachineDeclareUnoRunnable.java
@@ -50,19 +50,14 @@ public class MachineDeclareUnoRunnable implements Runnable {
                 }
 
                 MachinePlayer machinePlayer = gameController.getMachinePlayer(); // Asumiendo getter
-                boolean machineSuccessfullyDeclaredUno = false;
 
                 // Verificar si la máquina aún debe declarar UNO (no fue atrapada y sigue con 1 carta)
                 if (machinePlayer.isUnoCandidate() && !machinePlayer.hasDeclaredUnoThisTurn()) {
                     gameController.getGameState().playerDeclaresUno(machinePlayer);
                     gameController.getGameView().displayMessage("¡Máquina dice UNO!"); // Asumiendo getter
-                    machineSuccessfullyDeclaredUno = true;
                 }
-
-                // Si la máquina efectivamente declaró UNO, ya no se le puede castigar
-                if (machineSuccessfullyDeclaredUno) {
-                    gameController.setCanPunishMachine(false);
-                }
+                // Siempre se procede a cerrar la ventana de oportunidad de UNO/castigo,
+                this.gameController.proceedWithGameAfterMachineUnoWindow();
             });
 
         } catch (InterruptedException e) {

--- a/src/main/java/univalle/tedesoft/uno/view/GameView.java
+++ b/src/main/java/univalle/tedesoft/uno/view/GameView.java
@@ -652,11 +652,10 @@ public class GameView extends Stage {
     /**
      * Actualiza la visibilidad y el estado de habilitación del botón para castigar a la máquina.
      */
-    public void updatePunishUnoButtonVisuals(boolean shouldShowButton, boolean isCurrentPlayerHuman, boolean isGameOver, boolean isChoosingColor) {
+    public void updatePunishUnoButtonVisuals(boolean shouldShowButton, boolean isGameOver, boolean isChoosingColor) {
         Platform.runLater(() -> {
             if (this.gameController.punishUnoButton != null) {
                 boolean makeButtonVisibleAndEnabled = shouldShowButton &&
-                        isCurrentPlayerHuman &&
                         !isGameOver &&
                         !isChoosingColor;
                 this.gameController.punishUnoButton.setVisible(makeButtonVisibleAndEnabled);


### PR DESCRIPTION
A new method has been added and implemented to delay actions when there is a UNO penalty window. Logic related to the UNO penalty window for the machine has also been modified.